### PR TITLE
Only add handlers to FluxWebSockets once

### DIFF
--- a/flux-sdk-common/spec/unit/utils/flux-web-socket-spec.js
+++ b/flux-sdk-common/spec/unit/utils/flux-web-socket-spec.js
@@ -112,6 +112,23 @@ describe('utils.FluxWebSocket', function() {
         expect(this.handlerSpy2).not.toHaveBeenCalled();
       });
     });
+
+    describe('when the handler has been added multiple times', function() {
+      beforeEach(function() {
+        this.fluxWebSocket.addHandler('SUBCHANNEL', this.handlerSpy1);
+      });
+
+      it('should only get called once', function() {
+        this.reconnectingWebSocketSpy.emit('message', {
+          data: JSON.stringify({
+            type: 'SUBCHANNEL',
+            body: 'MESSAGE DATA',
+          }),
+        });
+
+        expect(this.handlerSpy1).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe('#removeHandler', function() {

--- a/flux-sdk-common/src/utils/flux-web-socket.js
+++ b/flux-sdk-common/src/utils/flux-web-socket.js
@@ -60,14 +60,22 @@ function FluxWebSocket(fetchWebSocketPath, options) {
     }));
   }
 
+  function hasHandler(subchannel, handler) {
+    return handlers[subchannel].indexOf(handler) !== -1;
+  }
+
   function addHandler(subchannel, handler) {
     handlers[subchannel] = handlers[subchannel] || [];
-    handlers[subchannel].push(handler);
+
+    if (!hasHandler(subchannel, handler)) {
+      handlers[subchannel].push(handler);
+    }
   }
 
   function removeHandler(subchannel, handler) {
     const subchannelHandlers = handlers[subchannel] || [];
     const index = subchannelHandlers.indexOf(handler);
+
     if (index !== -1) { subchannelHandlers.splice(index, 1); }
   }
 


### PR DESCRIPTION
This fixes a bug where reopening a given web socket
(e.g., via dataTable.openWebSocket) would cause all
user-defined handlers for that web socket to get
called once.

Fixes #1