### PR TITLE
#7 #8 Fixes cell updating, including (un)locking

### DIFF
--- a/flux-sdk-common/package.json
+++ b/flux-sdk-common/package.json
@@ -49,6 +49,7 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
+    "humps": "^1.1.0",
     "is-my-json-valid": "^2.13.1",
     "jws": "^3.1.3"
   }


### PR DESCRIPTION
Since `IgnoreValue` is now set, cells can a) be unlocked, and b) get updated without their value being overridden.

Similarly, the cell's new changes are now merged with the cell's prior client metadata, which prevents unspecified options from being overridden.

For example, `cell.update({ label: 'new label' })` will now leave the cell's description unchanged.