### PR TITLE
Send the correct payload in fetchHistory

### DIFF
--- a/flux-sdk-common/spec/unit/models/data-table-spec.js
+++ b/flux-sdk-common/spec/unit/models/data-table-spec.js
@@ -179,10 +179,10 @@ describe('models.DataTable', function() {
               fluxOptions: true,
               body: {
                 historyQuery: {
-                  cellIds: ['CELL1', 'CELL2'],
+                  cells: ['CELL1', 'CELL2'],
                   cursor: '2',
                   limit: 5,
-                  eventTypes: ['CELL_MODIFIED'],
+                  types: ['CELL_MODIFIED'],
                   begin: 1000,
                   end: 2000,
                   values: ['FOO'],

--- a/flux-sdk-common/spec/unit/utils/request-spec.js
+++ b/flux-sdk-common/spec/unit/utils/request-spec.js
@@ -110,11 +110,11 @@ describe('utils.request', function() {
 
     describe('when the request returns with an error status', function() {
       beforeEach(function() {
-        this.textSpy = jasmine.createSpy('text').and.returnValue(Promise.resolve('TEXT'));
+        this.textSpy = jasmine.createSpy('text')
+          .and.returnValue(Promise.resolve('something bad happened'));
         fetchPort.fetch.and.returnValue(Promise.resolve({
           status: 500,
           text: this.textSpy,
-          statusText: 'something bad happened',
         }));
       });
 
@@ -122,12 +122,12 @@ describe('utils.request', function() {
         request('SOME_PATH')
           .then(done.fail)
           .catch(err => {
-            expect(err.message).toEqual('500 something bad happened: TEXT');
+            expect(err.message).toEqual('500: something bad happened');
             expect(err.response).toEqual({
               status: 500,
-              statusText: 'something bad happened',
               text: this.textSpy,
             });
+            expect(err.status).toEqual(500);
             done();
           });
       });

--- a/flux-sdk-common/src/models/data-table.js
+++ b/flux-sdk-common/src/models/data-table.js
@@ -133,21 +133,23 @@ function DataTable(credentials, id) {
   function fetchHistory(options = {}) {
     const { cellIds, limit, values, eventTypes, startTime, endTime, page } = options;
     const begin = startTime ? { begin: startTime } : null;
-    const end = startTime ? { end: endTime } : null;
+    const end = endTime ? { end: endTime } : null;
     const cursor = page ? { cursor: page.toString() } : null;
+    const cells = cellIds ? { cells: cellIds } : null;
+    const types = eventTypes ? { types: eventTypes } : null;
 
     return authenticatedRequest(credentials, historyPath, {
       method: 'post',
       fluxOptions: true,
       body: {
         historyQuery: {
-          cellIds,
           limit,
           values,
-          eventTypes,
           ...cursor,
           ...begin,
           ...end,
+          ...cells,
+          ...types,
         },
       },
     })

--- a/flux-sdk-common/src/utils/request.js
+++ b/flux-sdk-common/src/utils/request.js
@@ -46,9 +46,8 @@ function handleError(response) {
   return response.text()
     .then(text => {
       const status = response.status;
-      const statusText = response.statusText || text;
+      const error = new Error(`${status}: ${text}`);
 
-      const error = new Error(`${status}: ${statusText}`);
       error.response = response;
       error.status = status;
 

--- a/flux-sdk-common/src/utils/request.js
+++ b/flux-sdk-common/src/utils/request.js
@@ -46,9 +46,9 @@ function handleError(response) {
   return response.text()
     .then(text => {
       const status = response.status;
-      const statusText = response.statusText || 'Zut alors!';
+      const statusText = response.statusText || text;
 
-      const error = new Error(`${status} ${statusText}: ${text}`);
+      const error = new Error(`${status}: ${statusText}`);
       error.response = response;
       error.status = status;
 


### PR DESCRIPTION
This allows users to (correcty) filter by cell IDs or event types.

Closes #14