### PR TITLE
Fixes creation of valueless cells

### DIFF
--- a/flux-sdk-common/spec/unit/models/cell-spec.js
+++ b/flux-sdk-common/spec/unit/models/cell-spec.js
@@ -285,7 +285,7 @@ describe('models.Cell.static', function() {
             fluxOptions: {
               Metadata: true,
               ClientMetadata: { Label: 'NEW KEY' },
-              IgnoreValue: true,
+              IgnoreValue: false,
             },
           })
         );

--- a/flux-sdk-common/src/models/cell.js
+++ b/flux-sdk-common/src/models/cell.js
@@ -22,7 +22,7 @@ function updateCell(credentials, dataTableId, id, cellOptions = {}) {
   const fluxOptions = {
     Metadata: true,
     ClientMetadata: clientMetadata,
-    IgnoreValue: !value,
+    IgnoreValue: value === undefined,
   };
 
   return authenticatedRequest(credentials, cellPath(dataTableId, id), {
@@ -41,7 +41,8 @@ function listCells(credentials, dataTableId) {
 }
 
 function createCell(credentials, dataTableId, label, cellOptions = {}) {
-  return updateCell(credentials, dataTableId, '', { label, ...cellOptions });
+  const value = cellOptions.value || null;
+  return updateCell(credentials, dataTableId, '', { label, value, ...cellOptions });
 }
 
 function fetchCellMetadata(credentials, dataTableId, cellId) {


### PR DESCRIPTION
We cannot set the "IgnoreValue" flag to true when creating a cell, even if the user is not providing a value.

Closes #7