### PR TITLE
Set 'role' and 'kind' keys for projects

### DIFF
--- a/flux-sdk-common/spec/unit/serializers/project-serializer-spec.js
+++ b/flux-sdk-common/spec/unit/serializers/project-serializer-spec.js
@@ -8,6 +8,8 @@ describe('serializers.projectSerializer', function() {
         name: 'PROJECT NAME',
         creator_id: 'CREATOR_ID',
         creator: 'CREATOR NAME',
+        acl: 'owner',
+        kind: 'full',
       });
       const serializedProject = serialize(projectResponse);
 
@@ -17,6 +19,8 @@ describe('serializers.projectSerializer', function() {
       expect(serializedProject.creatorName).toEqual('CREATOR NAME');
       expect(serializedProject.timeCreated).toEqual(jasmine.any(Date));
       expect(serializedProject.timeUpdated).toEqual(jasmine.any(Date));
+      expect(serializedProject.acl).toEqual('owner');
+      expect(serializedProject.kind).toEqual('full');
     });
   });
 

--- a/flux-sdk-common/src/serializers/project-serializer.js
+++ b/flux-sdk-common/src/serializers/project-serializer.js
@@ -6,6 +6,8 @@ function serialize(entity) {
     creatorName: entity.creator,
     timeCreated: new Date(entity.created_at),
     timeUpdated: new Date(entity.last_updated),
+    acl: entity.acl,
+    kind: entity.kind,
   };
 }
 


### PR DESCRIPTION
These keys can be used to determine the user's permissions for a project (e.g., whether it read-only for them).