### PR TITLE
Fix reconnecting web socket timeout reuse

### DIFF
--- a/flux-sdk-common/spec/unit/utils/reconnect-web-socket-spec.js
+++ b/flux-sdk-common/spec/unit/utils/reconnect-web-socket-spec.js
@@ -3,6 +3,8 @@ import * as webSocketPort from '../../../src/ports/web-socket';
 
 describe('utils.ReconnectingWebSocket', function() {
   beforeEach(function() {
+    jasmine.clock().install();
+
     // Sadly, this spy needs to be quite substantial
     // to mimic the relevant WebSocket behaviour :(
     this.webSocketSpy = {
@@ -53,12 +55,13 @@ describe('utils.ReconnectingWebSocket', function() {
         .then(this.webSocketSpy.open)
         .then(callback);
     };
-
-    jasmine.clock().install();
   });
 
-  afterEach(function() {
+  afterEach(function(done) {
+    // We make this async to handle weird pollution that otherwise
+    // seems to come from the clock.
     jasmine.clock().uninstall();
+    setTimeout(done, 0);
   });
 
   describe('#connect', function() {
@@ -232,6 +235,9 @@ describe('utils.ReconnectingWebSocket', function() {
 
   describe('when the web socket has an error', function() {
     beforeEach(function(done) {
+      this.onErrorSpy = jasmine.createSpy('onError');
+      this.reconnectingWebSocket.on('error', this.onErrorSpy);
+
       this.openWebSocket(() => {
         this.fetchWebSocketPathSpy.calls.reset();
 

--- a/flux-sdk-common/src/utils/reconnecting-web-socket.js
+++ b/flux-sdk-common/src/utils/reconnecting-web-socket.js
@@ -27,11 +27,18 @@ function ReconnectingWebSocket(fetchWebSocketPath, options = {}) {
     connect();
   }
 
+  function resetTimeouts() {
+    isReconnecting = false;
+    clearTimeout(attemptReconnectId);
+    clearTimeout(errorTimeoutId);
+  }
+
   function onError(error) {
-    self.emit('error', error);
+    resetTimeouts();
     webSocket = null;
     killed = true;
-    clearTimeout(attemptReconnectId);
+
+    self.emit('error', error);
   }
 
   function reconnect() {
@@ -44,10 +51,11 @@ function ReconnectingWebSocket(fetchWebSocketPath, options = {}) {
   }
 
   function onOpen() {
-    self.emit('open');
-    clearTimeout(errorTimeoutId);
+    resetTimeouts();
     buffer.forEach(send);
     buffer.splice(0);
+
+    self.emit('open');
   }
 
   function onMessage(message) {


### PR DESCRIPTION
This fixes the flakey tests and related issues.

To observe the flakiness, checkout the commit prior to this one and run the tests with seeds 21227 (which will fail) and 21228 (which will pass), e.g., `npm test -- --seed=21227`

Closes #31