### PR TITLE
Handles Unicode characters in the browser version

### DIFF
--- a/flux-sdk-browser/package.json
+++ b/flux-sdk-browser/package.json
@@ -16,11 +16,10 @@
     "build:es": "babel src -d es -s",
     "build:umd": "cross-env BABEL_ENV=commonjs webpack src/index.js dist/flux-sdk.js --debug",
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack src/index.js dist/flux-sdk-min.js -p",
-    "check": "npm run lint && npm test",
+    "check": "npm run lint",
     "clean": "rimraf dist es lib",
     "lint": "eslint src spec example/example.js",
-    "prepublish": "npm run clean && npm run build",
-    "test": "cross-env BABEL_ENV=commonjs babel-node ./node_modules/.bin/jasmine"
+    "prepublish": "npm run clean && npm run build"
   },
   "author": "Flux Factory, Inc. (https://flux.io)",
   "contributors": [

--- a/flux-sdk-browser/src/index.js
+++ b/flux-sdk-browser/src/index.js
@@ -20,11 +20,27 @@ function parseUrl(url) {
   };
 }
 
+// b64DecodeUnicode and b64EncodeUnicode are from
+// https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#Solution_1_–_escaping_the_string_before_encoding_it
+/* eslint-disable */
+function b64DecodeUnicode(str) {
+  return decodeURIComponent(Array.prototype.map.call(atob(str), function(c) {
+    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+  }).join(''));
+}
+
+function b64EncodeUnicode(str) {
+  return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+    return String.fromCharCode('0x' + p1);
+  }));
+}
+/* eslint-enable */
+
 const WrappedFluxSdk = fluxSdkWrapper({
   WebSocket,
   fetch: window.fetch,
-  base64Decode: atob,
-  base64Encode: btoa,
+  base64Decode: b64DecodeUnicode,
+  base64Encode: b64EncodeUnicode,
   parseUrl,
   parseQuery: qs.parse,
   stringifyQuery: qs.stringify,


### PR DESCRIPTION
Previously, we weren't explicitly escaping strings when base64-encoding/decoding them. This is necessary in the browser when using window.atob and window.btoa (https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding).