### PR TITLE
Make the current version easily accessible

### DIFF
--- a/flux-sdk-common/src/models/flux-sdk.js
+++ b/flux-sdk-common/src/models/flux-sdk.js
@@ -9,6 +9,8 @@ import * as models from './index';
 import * as constants from '../constants';
 import { setFluxUrl } from '../utils/request';
 
+import { VERSION } from '../config';
+
 function FluxSdk(clientId, sdkOptions = {}) {
   const {
     fluxUrl,
@@ -49,5 +51,7 @@ function FluxSdk(clientId, sdkOptions = {}) {
 
 Object.keys(models).forEach(key => { FluxSdk.prototype[key] = models[key]; });
 FluxSdk.prototype.constants = constants;
+
+FluxSdk.prototype.version = FluxSdk.version = VERSION;
 
 export default FluxSdk;


### PR DESCRIPTION
This adds the current version as FluxSdk.version or sdk.version, where sdk is an instance of FluxSdk.