### PR TITLE
Allow cells to have falsey values

### DIFF
--- a/flux-sdk-common/spec/unit/models/cell-spec.js
+++ b/flux-sdk-common/spec/unit/models/cell-spec.js
@@ -270,6 +270,34 @@ describe('models.Cell.static', function() {
       });
     });
 
+    describe('when there is a falsey value', function() {
+      beforeEach(function(done) {
+        Cell.createCell(this.credentials, 'DATA_TABLE_ID', 'NEW KEY', {
+          value: false,
+          description: 'FOO',
+        })
+          .then(response => {
+            this.response = response;
+          })
+          .then(done, done.fail);
+      });
+
+      it('should set the value and client metadata of the new cell', function() {
+        expect(requestUtils.authenticatedRequest).toHaveBeenCalledWith(
+          this.credentials,
+          'p/DATA_TABLE_ID/api/datatable/v1/cells/', {
+            method: 'post',
+            fluxOptions: {
+              Metadata: true,
+              ClientMetadata: { Label: 'NEW KEY', Description: 'FOO' },
+              IgnoreValue: false,
+            },
+            body: false,
+          }
+        );
+      });
+    });
+
     describe('when there is no value', function() {
       beforeEach(function(done) {
         Cell.createCell(this.credentials, 'DATA_TABLE_ID', 'NEW KEY')

--- a/flux-sdk-common/spec/unit/utils/request-spec.js
+++ b/flux-sdk-common/spec/unit/utils/request-spec.js
@@ -96,6 +96,19 @@ describe('utils.request', function() {
       });
     });
 
+    describe('when a falsey body is specified', function() {
+      beforeEach(function() {
+        request('SOME_PATH', { body: false });
+      });
+
+      it('should send the body', function() {
+        expect(fetchPort.fetch).toHaveBeenCalledWith('JOINED_URL', jasmine.objectContaining({
+          credentials: 'include',
+          body: JSON.stringify(false),
+        }));
+      });
+    });
+
     describe('when additional options are added', function() {
       it('should add them to the fetch request', function() {
         request('SOME_PATH', { headers: { a: 'b' }, foo: 'bar' });

--- a/flux-sdk-common/src/models/cell.js
+++ b/flux-sdk-common/src/models/cell.js
@@ -41,7 +41,7 @@ function listCells(credentials, dataTableId) {
 }
 
 function createCell(credentials, dataTableId, label, cellOptions = {}) {
-  const value = cellOptions.value || null;
+  const value = cellOptions.value === undefined ? null : cellOptions.value;
   return updateCell(credentials, dataTableId, '', { label, value, ...cellOptions });
 }
 

--- a/flux-sdk-common/src/utils/request.js
+++ b/flux-sdk-common/src/utils/request.js
@@ -65,7 +65,7 @@ function handleResponse(response) {
 
 function request(path, options = {}) {
   const { query, body, headers, ...others } = options;
-  const payload = body ? { body: JSON.stringify(body) } : null;
+  const payload = body === undefined ? null : { body: JSON.stringify(body) };
   const contentType = payload ? { 'Content-Type': 'application/json' } : null;
   const search = query ? stringifyQuery(query) : '';
 

--- a/flux-sdk-node/spec/e2e/cell-spec.js
+++ b/flux-sdk-node/spec/e2e/cell-spec.js
@@ -147,6 +147,56 @@ describe('Cell', function() {
           });
         });
 
+        describe('when the value is updated', function() {
+          beforeAll(function(done) {
+            this.cell.update({ value: 'new value' })
+              .then(({ transformed }) => {
+                this.transformed = transformed;
+              })
+              .then(done, done.fail);
+          });
+
+          afterAll(function(done) {
+            this.cell.update({ value: this.originalValue }).then(done, done.fail);
+          });
+
+          it('should change only the value', function(done) {
+            this.cell.fetch()
+              .then(({ transformed }) => {
+                expect(transformed.value).toEqual('new value');
+
+                expect(transformed.label).toEqual(this.originalLabel);
+                expect(transformed.description).toEqual(this.originalDescription);
+              })
+              .then(done, done.fail);
+          });
+        });
+
+        describe('when the value is updated with a falsey value', function() {
+          beforeAll(function(done) {
+            this.cell.update({ value: false })
+              .then(({ transformed }) => {
+                this.transformed = transformed;
+              })
+              .then(done, done.fail);
+          });
+
+          afterAll(function(done) {
+            this.cell.update({ value: this.originalValue }).then(done, done.fail);
+          });
+
+          it('should change only the value', function(done) {
+            this.cell.fetch()
+              .then(({ transformed }) => {
+                expect(transformed.value).toEqual(false);
+
+                expect(transformed.label).toEqual(this.originalLabel);
+                expect(transformed.description).toEqual(this.originalDescription);
+              })
+              .then(done, done.fail);
+          });
+        });
+
         describe('when the cell gets locked', function() {
           beforeAll(function(done) {
             this.cell.update({ locked: true })


### PR DESCRIPTION
Previously, cells that were updated or created with falsey values would (often incorrectly) have their values set as null or empty the string.