### PR TITLE
Adjust e2e tests to back end changes

### DIFF
--- a/flux-sdk-node/spec/e2e/data-table-spec.js
+++ b/flux-sdk-node/spec/e2e/data-table-spec.js
@@ -105,8 +105,8 @@ describe('DataTable', function() {
       });
 
       it('should receive the history for the full data table', function() {
-        expect(this.original.errStr).toEqual('');
-        expect(this.original.historyQuery).toEqual(null);
+        expect(this.original.errStr).toEqual(undefined);
+        expect(this.original.historyQuery).toEqual(undefined);
 
         expect(this.original.historyEvents).toEqual(jasmine.any(Array));
 


### PR DESCRIPTION
Now that the back end only sends values for the history error and cursor if they actually exist, we need to change the expectations of the tests.