### PR TITLE
Increases the E2E test timeout limit

### DIFF
--- a/flux-sdk-node/spec/helpers/setup.js
+++ b/flux-sdk-node/spec/helpers/setup.js
@@ -4,6 +4,8 @@ import credentialsFactory from '../../../flux-sdk-common/spec/factories/credenti
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
+
 beforeAll(function() {
   const accessToken = process.env.ACCESS_TOKEN;
   const fluxToken = process.env.FLUX_TOKEN;


### PR DESCRIPTION
Since some endpoints were often taking longer than the default timeout limit (5 seconds) for the E2E tests, and API performance cannot be affected by the SDK, we are increasing the timeout limit to make the tests more reliable.