### PR TITLE
Allow bulk removal of data table web socket handlers

### DIFF
--- a/docs/api/DataTable.md
+++ b/docs/api/DataTable.md
@@ -10,8 +10,9 @@ Instance methods:
 * [createCell](./DataTable.md#createcell)
 * [openWebSocket](./DataTable.md#openwebsocket)
 * [closeWebSocket](./DataTable.md#closewebsocket)
-* [addWebSocketHandler](./DataTable.md#addWebSocketHandler)
-* [removeWebSocketHandler](./DataTable.md#removeWebSocketHandler)
+* [addWebSocketHandler](./DataTable.md#addwebsockethandler)
+* [removeWebSocketHandler](./DataTable.md#removewebsockethandler)
+* [removeWebSocketHandlers](./DataTable.md#removewebsockethandlers)
 * [sendMessage](./DataTable.md#sendMessage)
 
 Static properties:
@@ -128,9 +129,15 @@ delayMultiplier: Number }`)*
   `delayMultiplier` (default: `1.2`): How much to increase the delay each time
   there is a failed connection attempt
 
-### <a id="closewebsocket"></a>`closeWebSocket()`
+### <a id="closewebsocket"></a>`closeWebSocket(removeHandlers)`
 
 Closes the web socket, if a web socket has been opened for the data table.
+
+#### Arguments
+
+1. `removeHandlers` *(Boolean)*: Whether the registered handlers for the data
+table's web socket should be reset. If true, the handlers will no longer be
+called if and when the data table's web socket is reopened.
 
 ### <a id="addwebsockethandler"></a>`addWebSocketHandler(handler,s [notificationTypes])`
 
@@ -167,6 +174,18 @@ web socket receives messages.
 1. `notificationTypes` *(String | String[])*: The type or types of notifications
 for which the handler should no longer be called. If no types are supplied, the
 handler will be removed completely.
+
+### <a id="removewebsockethandlers"></a>`removeWebSocketHandlers([notificationTypes])`
+
+Removes all handlers, or all handlers of the specified notification type(s), such
+that the handlers will no longer be called when the data table's web socket
+receives messages.
+
+#### Arguments
+
+1. `?notificationTypes` *(String | String[])*: The type or types of notifications
+for which handlers should no longer be called. If no types are supplied, all
+handlers will be removed completely.
 
 ### <a id="sendmessage"></a>`sendmessage(message)`
 

--- a/flux-sdk-common/src/models/data-table.js
+++ b/flux-sdk-common/src/models/data-table.js
@@ -34,7 +34,7 @@ function DataTable(credentials, id) {
   checkDataTable({ credentials, id });
 
   let webSocket = null;
-  const handlers = initializeHandlers();
+  let handlers = initializeHandlers();
   const capabilityPath = dataTableCapabilityPath(id);
   const historyPath = dataTableHistoryPath(id);
 
@@ -73,7 +73,11 @@ function DataTable(credentials, id) {
     return webSocket;
   }
 
-  function closeWebSocket() {
+  function closeWebSocket(removeHandlers) {
+    if (removeHandlers) {
+      removeWebSocketHandlers();
+    }
+
     if (webSocket) {
       webSocket.send(DATA_TABLE_SUBCHANNEL, {
         type: SUBSCRIBE,
@@ -94,6 +98,16 @@ function DataTable(credentials, id) {
       const index = handlers[type].indexOf(handler);
       if (index !== -1) { handlers[type].splice(index, 1); }
     });
+  }
+
+  function removeWebSocketHandlers(notificationTypes) {
+    if (notificationTypes) {
+      [].concat(notificationTypes).forEach(type => {
+        handlers[type] = [];
+      });
+    } else {
+      handlers = initializeHandlers();
+    }
   }
 
   function sendMessage(message) {
@@ -159,6 +173,7 @@ function DataTable(credentials, id) {
   this.closeWebSocket = closeWebSocket;
   this.addWebSocketHandler = addWebSocketHandler;
   this.removeWebSocketHandler = removeWebSocketHandler;
+  this.removeWebSocketHandlers = removeWebSocketHandlers;
   this.sendMessage = sendMessage;
   this.fetchCapability = fetchCapability;
   this.listCells = listCells;


### PR DESCRIPTION
Via `dataTable.removeWebSocketHandlers`, users can now remove either all of the web socket handlers for a data table, or all of the handlers of a particular type.

All handlers (for all notification types) can also be removed when the web socket is closed, via `dataTable.closeWebSocket`.