### PR TITLE
Adds filename and arbitrary query options to fetchHistory

### DIFF
--- a/flux-sdk-common/spec/factories/history-response-factory.js
+++ b/flux-sdk-common/spec/factories/history-response-factory.js
@@ -8,7 +8,7 @@ function historyQueryFactory(limit, cursor) {
 }
 
 function historyResponseFactory(options = {}) {
-  const { limit, cursor } = options;
+  const { limit, cursor, fileName } = options;
   const historyQuery = historyQueryFactory(limit, cursor);
   return {
     historyQuery,
@@ -21,7 +21,10 @@ function historyResponseFactory(options = {}) {
           ClientId: 'CLIENT_ID',
           ClientName: 'CLIENT NAME',
           ClientVersion: '',
-          AdditionalClientData: { HostProgramMainFile: '', HostProgramVersion: '' },
+          AdditionalClientData: {
+            HostProgramMainFile: fileName || '',
+            HostProgramVersion: '',
+          },
           SDKName: '',
           SDKVersion: '',
           OS: 'BROWSER_USER_AGENT',
@@ -34,7 +37,6 @@ function historyResponseFactory(options = {}) {
         Size: 4,
       },
     }],
-    errStr: '',
   };
 }
 

--- a/flux-sdk-common/spec/unit/models/data-table-spec.js
+++ b/flux-sdk-common/spec/unit/models/data-table-spec.js
@@ -171,6 +171,7 @@ describe('models.DataTable', function() {
         startTime: 1000,
         endTime: 2000,
         values: ['FOO'],
+        foo: 'bar',
       })
         .then(() => {
           expect(requestUtils.authenticatedRequest)
@@ -186,6 +187,7 @@ describe('models.DataTable', function() {
                   begin: 1000,
                   end: 2000,
                   values: ['FOO'],
+                  foo: 'bar',
                 },
               },
             });

--- a/flux-sdk-common/spec/unit/serializers/history-serializer-spec.js
+++ b/flux-sdk-common/spec/unit/serializers/history-serializer-spec.js
@@ -4,7 +4,9 @@ import historyFactory from './../../factories/history-response-factory';
 describe('serializers.historySerializer', function() {
   describe('#serialize', function() {
     it('should serialize the events', function() {
-      const historyResponse = historyFactory();
+      const historyResponse = historyFactory({
+        fileName: 'foo.xls',
+      });
       const serializedHistory = serialize(historyResponse);
       const entities = serializedHistory.entities;
 
@@ -21,6 +23,7 @@ describe('serializers.historySerializer', function() {
       expect(event.authorName).toEqual('USERNAME');
       expect(event.clientId).toEqual('CLIENT_ID');
       expect(event.clientName).toEqual('CLIENT NAME');
+      expect(event.hostFileName).toEqual('foo.xls');
     });
 
     describe('with no historyCursor', function() {

--- a/flux-sdk-common/src/models/data-table.js
+++ b/flux-sdk-common/src/models/data-table.js
@@ -145,7 +145,7 @@ function DataTable(credentials, id) {
   }
 
   function fetchHistory(options = {}) {
-    const { cellIds, limit, values, eventTypes, startTime, endTime, cursor } = options;
+    const { cellIds, limit, values, eventTypes, startTime, endTime, cursor, ...others } = options;
     const begin = startTime ? { begin: startTime } : null;
     const end = endTime ? { end: endTime } : null;
     const cells = cellIds ? { cells: cellIds } : null;
@@ -163,6 +163,7 @@ function DataTable(credentials, id) {
           ...end,
           ...cells,
           ...types,
+          ...others,
         },
       },
     })

--- a/flux-sdk-common/src/serializers/history-serializer.js
+++ b/flux-sdk-common/src/serializers/history-serializer.js
@@ -1,5 +1,7 @@
 function serializeEvent(event) {
   const clientInfo = event.ClientInfo || {};
+  const additionalData = clientInfo.AdditionalClientData || {};
+
   return {
     cellId: event.CellId,
     eventType: event.Type,
@@ -10,6 +12,7 @@ function serializeEvent(event) {
     clientName: clientInfo.ClientName,
     authorId: clientInfo.UserId,
     authorName: clientInfo.UserName,
+    hostFileName: additionalData.HostProgramMainFile,
   };
 }
 

--- a/flux-sdk-node/spec/e2e/data-table-spec.js
+++ b/flux-sdk-node/spec/e2e/data-table-spec.js
@@ -105,9 +105,6 @@ describe('DataTable', function() {
       });
 
       it('should receive the history for the full data table', function() {
-        expect(this.original.errStr).toEqual(undefined);
-        expect(this.original.historyQuery).toEqual(undefined);
-
         expect(this.original.historyEvents).toEqual(jasmine.any(Array));
 
         // We can't guarantee the length because it depends on the test order.
@@ -118,7 +115,11 @@ describe('DataTable', function() {
 
           expect(cellEvent.Type).toEqual('CELL_MODIFIED');
           expect(cellEvent.CellId).toEqual(jasmine.any(String));
-          expect(cellEvent.ClientInfo).toEqual(jasmine.any(Object));
+          expect(cellEvent.ClientInfo).toEqual(jasmine.objectContaining({
+            AdditionalClientData: jasmine.objectContaining({
+              HostProgramMainFile: jasmine.any(String),
+            }),
+          }));
           expect(cellEvent.Size).toEqual(jasmine.any(Number));
           expect(cellEvent.Time).toEqual(jasmine.any(Number));
           expect(cellEvent.ValueRef).toEqual(jasmine.any(String));


### PR DESCRIPTION
`dataTable.fetchHistory` and `cell.fetchHistory` now by default return the host file name of the change, and will send arbitrary query options in the request.