### PR TITLE
Specify file name for cell changes

### DIFF
--- a/flux-sdk-common/spec/factories/cell-response-factory.js
+++ b/flux-sdk-common/spec/factories/cell-response-factory.js
@@ -29,7 +29,7 @@ function cellFactory(id, overrides) {
           ClientName: `CLIENT NAME ${id}`,
           ClientVersion: '',
           AdditionalClientData: {
-            HostProgramMainFile: '',
+            HostProgramMainFile: 'some-file.csv',
             HostProgramVersion: '',
           },
           SDKName: '',

--- a/flux-sdk-common/spec/unit/serializers/cell-serializer-spec.js
+++ b/flux-sdk-common/spec/unit/serializers/cell-serializer-spec.js
@@ -22,6 +22,7 @@ describe('serializer.cellSerializer', function() {
       expect(serializedCell.authorName).toEqual('USERNAME_100');
       expect(serializedCell.clientId).toEqual('CLIENT_ID_100');
       expect(serializedCell.clientName).toEqual('CLIENT NAME 100');
+      expect(serializedCell.fileName).toEqual('some-file.csv');
     });
 
     describe('when the cell has a value', function() {

--- a/flux-sdk-common/src/serializers/cell-serializer.js
+++ b/flux-sdk-common/src/serializers/cell-serializer.js
@@ -4,6 +4,7 @@ function serialize(entity) {
   const lastModification = metadata.Modify || metadata.Create || {};
   const clientInfo = Object(lastModification.ClientInfo);
   const valueKey = entity.value !== undefined ? { value: entity.value } : null;
+  const additionalClientData = Object(clientInfo.AdditionalClientData);
 
   return {
     id: entity.CellId,
@@ -16,6 +17,7 @@ function serialize(entity) {
     authorName: clientInfo.UserName,
     clientId: clientInfo.ClientId,
     clientName: clientInfo.ClientName,
+    fileName: additionalClientData.HostProgramMainFile,
     ...valueKey,
   };
 }

--- a/flux-sdk-node/spec/e2e/cell-spec.js
+++ b/flux-sdk-node/spec/e2e/cell-spec.js
@@ -65,6 +65,10 @@ describe('Cell', function() {
         expect(clientInfo.ClientId).toEqual(this.CLIENT_ID);
         expect(clientInfo.ClientName).toEqual(jasmine.any(String));
 
+        expect(clientInfo.AdditionalClientData).toEqual(jasmine.objectContaining({
+          HostProgramMainFile: jasmine.any(String),
+        }));
+
         expect(cell.value).toEqual([10, 'something']);
       });
 
@@ -73,6 +77,7 @@ describe('Cell', function() {
         const clientMetadata = original.ClientMetadata;
         const lastModification = original.Metadata.Modify;
         const clientInfo = lastModification.ClientInfo;
+        const additionalClientData = clientInfo.AdditionalClientData;
 
         expect(this.transformed.id).toEqual(original.CellId);
         expect(this.transformed.label).toEqual(clientMetadata.Label);
@@ -84,6 +89,7 @@ describe('Cell', function() {
         expect(this.transformed.authorName).toEqual(clientInfo.UserName);
         expect(this.transformed.clientId).toEqual(clientInfo.ClientId);
         expect(this.transformed.clientName).toEqual(clientInfo.ClientName);
+        expect(this.transformed.fileName).toEqual(additionalClientData.HostProgramMainFile);
         expect(this.transformed.value).toEqual(original.value);
       });
     });


### PR DESCRIPTION
When a cell changes, users will now by default see the name of the file from which the change was made (if available).