### PR TITLE
Show more info when a cell is deleted

### DIFF
--- a/flux-sdk-common/spec/unit/serializers/cell-serializer-spec.js
+++ b/flux-sdk-common/spec/unit/serializers/cell-serializer-spec.js
@@ -68,6 +68,11 @@ describe('serializer.cellSerializer', function() {
       const serializedResponse = serializeDelete(cellResponse);
 
       expect(serializedResponse.id).toEqual(555);
+      expect(serializedResponse.authorId).toEqual('USER_ID_555');
+      expect(serializedResponse.authorName).toEqual('USERNAME_555');
+      expect(serializedResponse.clientId).toEqual('CLIENT_ID_555');
+      expect(serializedResponse.clientName).toEqual('CLIENT NAME 555');
+      expect(serializedResponse.fileName).toEqual('web');
     });
   });
 

--- a/flux-sdk-common/src/serializers/cell-serializer.js
+++ b/flux-sdk-common/src/serializers/cell-serializer.js
@@ -21,8 +21,18 @@ function serialize(entity) {
 }
 
 function serializeDelete(entity) {
+  const metadata = Object(entity.Metadata);
+  const lastModification = metadata.Modify || metadata.Create || {};
+  const clientInfo = Object(lastModification.ClientInfo);
+  const additionalClientData = Object(clientInfo.AdditionalClientData);
+
   return {
     id: entity.CellId,
+    authorId: clientInfo.UserId,
+    authorName: clientInfo.UserName,
+    clientId: clientInfo.ClientId,
+    clientName: clientInfo.ClientName,
+    fileName: additionalClientData.HostProgramMainFile,
   };
 }
 


### PR DESCRIPTION
Users will now see more information by default when a cell is deleted, including the name of the user who deleted it.