### PR TITLE
Added the ability to get totalCount from the history serializer

### DIFF
--- a/flux-sdk-common/spec/factories/history-response-factory.js
+++ b/flux-sdk-common/spec/factories/history-response-factory.js
@@ -8,7 +8,7 @@ function historyQueryFactory(limit, cursor) {
 }
 
 function historyResponseFactory(options = {}) {
-  const { limit, cursor, fileName } = options;
+  const { limit, cursor, fileName, totalCount } = options;
   const historyQuery = historyQueryFactory(limit, cursor);
   return {
     historyQuery,
@@ -37,6 +37,7 @@ function historyResponseFactory(options = {}) {
         Size: 4,
       },
     }],
+    totalCount: totalCount
   };
 }
 

--- a/flux-sdk-common/spec/unit/serializers/history-serializer-spec.js
+++ b/flux-sdk-common/spec/unit/serializers/history-serializer-spec.js
@@ -49,5 +49,16 @@ describe('serializers.historySerializer', function() {
         expect(this.serializedHistory.cursor).toEqual('FOO_CURSOR');
       });
     });
+
+    describe('with totalCount', function() {
+      beforeEach(function() {
+        const historyResponse = historyFactory({ totalCount: 100 });
+        this.serializedHistory = serialize(historyResponse);
+      });
+
+      it('should set the totalCount field', function() {
+        expect(this.serializedHistory.totalCount).toEqual(100);
+      });
+    });
   });
 });

--- a/flux-sdk-common/src/serializers/history-serializer.js
+++ b/flux-sdk-common/src/serializers/history-serializer.js
@@ -16,13 +16,14 @@ function serializeEvent(event) {
   };
 }
 
-function serialize({ historyEvents, historyQuery }) {
+function serialize({ historyEvents, historyQuery, totalCount }) {
   const query = historyQuery || {};
 
   return {
     entities: (historyEvents || []).map(event => serializeEvent(event.Event)),
     cursor: query.Cursor || null,
     limit: query.Limit || 0,
+    totalCount
   };
 }
 


### PR DESCRIPTION
Currently the history serializer will drop totalCount from the server response. This will stop that field from being dropped.