### PR TITLE
Add Flow-as-a-Service execution capability.

### DIFF
--- a/flux-sdk-common/spec/unit/models/project-spec.js
+++ b/flux-sdk-common/spec/unit/models/project-spec.js
@@ -130,6 +130,27 @@ describe('models.Project', function() {
         });
     });
   });
+
+
+  describe('#executeFlow', function() {
+    beforeEach(function(done) {
+      this.request = this.project.executeFlow({ INPUT_NAME: 'INPUT_VALUE' })
+        .then(response => {
+          this.response = response;
+        })
+        .then(done, done.fail);
+    });
+
+    it('should hit the execute flow endpoint', function() {
+      expect(requestUtils.authenticatedRequest).toHaveBeenCalledWith(
+        this.credentials, 'p/PROJECT_ID/api/flowexec', {
+          method: 'post',
+          body: {
+            inputs: { INPUT_NAME: 'INPUT_VALUE' },
+          },
+        });
+    });
+  });
 });
 
 describe('models.Project.static', function() {

--- a/flux-sdk-common/src/constants/paths.js
+++ b/flux-sdk-common/src/constants/paths.js
@@ -10,6 +10,7 @@ export const projectPath = id => `p/${id}/`;
 export const projectMetaPath = id => `${projectPath(id)}api/meta/`;
 export const projectUsersPath = id => `api/v1/projects/${id}/users/`;
 export const removeUserPath = (id, userId) => `${projectUsersPath(id)}${userId}`;
+export const execFlowPath = id => `p/${id}/api/flowexec`;
 
 const dataTablePath = id => `${projectPath(id)}api/datatable/v1/`;
 export const dataTableCapabilityPath = id => `${dataTablePath(id)}capability/`;

--- a/flux-sdk-common/src/models/project.js
+++ b/flux-sdk-common/src/models/project.js
@@ -95,10 +95,11 @@ function Project(credentials, id) {
     });
   }
 
-  function executeFlow(inputs) {
+  function executeFlow(inputs, options) {
     // Currently only for Flux internal use. Project must be whitelisted by a
     // Flux engineer for this method to work.
-    return authenticatedRequest(credentials, execFlowPath(id), {
+    const computeEndpoint = (options && options.computeEndpoint) || execFlowPath(id);
+    return authenticatedRequest(credentials, computeEndpoint, {
       method: 'post',
       body: {
         inputs,

--- a/flux-sdk-common/src/models/project.js
+++ b/flux-sdk-common/src/models/project.js
@@ -8,6 +8,7 @@ import {
   projectMetaPath,
   projectUsersPath,
   removeUserPath,
+  execFlowPath,
 } from '../constants/paths';
 import {
     COLLABORATOR,
@@ -94,6 +95,25 @@ function Project(credentials, id) {
     });
   }
 
+  function executeFlow(inputs) {
+    return authenticatedRequest(credentials, execFlowPath(id), {
+      method: 'post',
+      body: {
+        inputs,
+      },
+    }).then(resp => {
+      const errors = resp.Errors;
+      const outputs = resp.Outputs;
+      if (errors && errors.length && errors.length > 0) {
+        const error = new Error(`${errors.length} flow errors occurred.`);
+        error.messages = errors;
+        error.outputs = outputs;
+        throw error;
+      }
+      return outputs;
+    });
+  }
+
   this.fetch = fetch;
   this.delete = deleteProject;
   this.getDataTable = getDataTable;
@@ -102,6 +122,7 @@ function Project(credentials, id) {
   this.listUsers = listUsers;
   this.share = share;
   this.unshare = unshare;
+  this.executeFlow = executeFlow;
 }
 
 Project.listProjects = listProjects;

--- a/flux-sdk-common/src/models/project.js
+++ b/flux-sdk-common/src/models/project.js
@@ -96,6 +96,8 @@ function Project(credentials, id) {
   }
 
   function executeFlow(inputs) {
+    // Currently only for Flux internal use. Project must be whitelisted by a
+    // Flux engineer for this method to work.
     return authenticatedRequest(credentials, execFlowPath(id), {
       method: 'post',
       body: {

--- a/flux-sdk-node/spec/e2e/project-spec.js
+++ b/flux-sdk-node/spec/e2e/project-spec.js
@@ -15,6 +15,24 @@ describe('Project', function() {
       this.project.delete().then(done, done.fail);
     });
 
+    describe('#executeFlow', function() {
+      beforeAll(function(done) {
+        this.project.executeFlow({})
+        .then(outputs => {
+          this.outputs = outputs;
+        }).catch(err => {
+          this.errors = err.messages;
+          this.outputs = err.outputs;
+        })
+        .then(done, done.fail);
+      });
+
+      it('should receive no outputs and no errors', function() {
+        expect(this.outputs).toEqual({});
+        expect(this.errors).toBe(undefined);
+      });
+    });
+
     describe('#listUsers', function() {
       beforeAll(function(done) {
         this.project.listUsers()


### PR DESCRIPTION
Adds an `executeFlow` method to `Project`, adds new paths and describes unit and integration tests.