### PR TITLE
Serialization for snapshots

### DIFF
--- a/flux-sdk-common/README.md
+++ b/flux-sdk-common/README.md
@@ -23,7 +23,11 @@ sym-linked version to npm so that running `npm install flux-sdk-common`
 from another directory (e.g., `flux-sdk-js/flux-sdk-browser`) will use the
 local version.
 
-## <a id="installing"></a>Installing
+## <a id="installing"></a>Running Tests
+
+Make sure you set up your env by following these instructions
+https://docs.google.com/document/d/1joaFumoetcAfN9xCU-ND7vr2dMUXPGaNqa6syz_EqyU/edit#
+Also see the Testing section in flux-sdk-node/README.md
 
 * To run the linter and tests once: `npm run check`
 * To run the tests once (no linting): `npm test`

--- a/flux-sdk-common/src/models/bcf/viewpoint.js
+++ b/flux-sdk-common/src/models/bcf/viewpoint.js
@@ -12,6 +12,8 @@ import {
   serializeList,
 } from '../../serializers/bcf/viewpoint';
 
+import * as Snapshot from '../../serializers/bcf/snapshot';
+
 const snapshotMimeTypes = {
   png: 'image/png',
   jpg: 'image/jpeg',
@@ -53,13 +55,12 @@ function _createSnapshot(credentials, projectId, topicId, viewpointId, snapshot)
       'Content-Type': contentType,
     },
     method: 'post',
-  });
-  // TODO(alcorn) BCF snapshot serializer
+  }).then(Snapshot.serialize);
 }
 
 function _getSnapshot(credentials, projectId, topicId, viewpointId) {
-  return authenticatedRequest(credentials, bcfSnapshotPath(projectId, topicId, viewpointId));
-  // TODO(alcorn) BCF snapshot serializer
+  return authenticatedRequest(credentials, bcfSnapshotPath(projectId, topicId, viewpointId))
+    .then(Snapshot.serialize);
 }
 
 function Viewpoint(credentials, projectId, topicId, viewpointId) {

--- a/flux-sdk-common/src/serializers/bcf/snapshot.js
+++ b/flux-sdk-common/src/serializers/bcf/snapshot.js
@@ -1,0 +1,13 @@
+function serialize(snapshot) {
+  // Snapshot is already a base64 string promise, see request.js handleImage
+  return snapshot;
+}
+
+function serializeList(viewpoints) {
+  return viewpoints.map(serialize);
+}
+
+export {
+  serialize,
+  serializeList,
+};

--- a/flux-sdk-common/src/utils/request.js
+++ b/flux-sdk-common/src/utils/request.js
@@ -43,7 +43,18 @@ function handleAuxiliaryResponse(response) {
 
 // Returns the response body as a stream.
 function handleImage(response) {
-  return response.body;
+  const content = response.headers.get('content-type');
+  const snapshot = response.body;
+  return new Promise((resolve) => {
+    snapshot.on('readable', () => {
+      const buffer = snapshot.read();
+      if (buffer !== null && buffer !== undefined) {
+        const str64 = buffer.toString('base64');
+        const img = `data:${content};base64,${str64}`;
+        resolve(img);
+      }
+    });
+  });
 }
 
 function handleSuccess(response) {

--- a/flux-sdk-node/package.json
+++ b/flux-sdk-node/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint src spec example/app.js",
     "prepublish": "npm run clean && npm run build",
     "test": "npm run test:e2e",
-    "test:e2e": "cross-env NODE_ENV=test BABEL_ENV=commonjs babel-node node_modules/.bin/jasmine --random=true --verbose",
+    "test:e2e": "cross-env NODE_ENV=test BABEL_ENV=commonjs babel-node node_modules/.bin/jasmine --random=true",
     "test:watch": "nodemon -x 'npm test' -w src -w spec"
   },
   "author": "Flux Factory, Inc. (https://flux.io)",

--- a/flux-sdk-node/spec/e2e/bcf/viewpoint-spec.js
+++ b/flux-sdk-node/spec/e2e/bcf/viewpoint-spec.js
@@ -80,9 +80,10 @@ describe('Viewpoint', function() {
       it('should get the viewpoint\'s snapshot', function(done) {
         this.topic.createViewpoint(testViewpoint)
         .then((viewpoint) => {
-          return viewpoint.getSnapshot();
-        })
-        .then(done, done.fail);
+          viewpoint.getSnapshot().then((snapshot) => {
+            expect(snapshot).toContain('data:image/png;base64,');
+          }).then(done, done.fail);
+        });
       });
     });
 


### PR DESCRIPTION
Now fetch will automatically serialize all image responses from the
server as data uri's.