### PR TITLE
v052

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ While the API is considered unstable until we reach `1.0.0`, we will attempt
 to increment the minor version (`Y` in `x.Y.z`) if and when there are
 breaking changes.
 
+## [0.5.2] - 11/29/2017
+
+* Raw request object is now returned for Issue viewpoint snapshots, leaving the handling up to the client.
+
 ## [0.5.1] - 11/29/2017
 
 * Issue viewpoint snapshots now returned as image uris.

--- a/flux-sdk-apps-script/package.json
+++ b/flux-sdk-apps-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-sdk-apps-script",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Flux JavaScript SDK for Google Apps Script clients",
   "main": "dist/index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "flux-sdk-common": "0.5.1",
+    "flux-sdk-common": "0.5.2",
     "query-string": "^4.1.0"
   },
   "devDependencies": {

--- a/flux-sdk-browser/package.json
+++ b/flux-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-sdk-browser",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Flux JavaScript SDK for browser clients",
   "files": [
     "dist",
@@ -49,7 +49,7 @@
     "webpack": "^1.12.14"
   },
   "dependencies": {
-    "flux-sdk-common": "^0.5.1",
+    "flux-sdk-common": "^0.5.2",
     "query-string": "^3.0.3",
     "whatwg-fetch": "^0.11.0"
   }

--- a/flux-sdk-common/package.json
+++ b/flux-sdk-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-sdk-common",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",

--- a/flux-sdk-common/src/utils/request.js
+++ b/flux-sdk-common/src/utils/request.js
@@ -43,18 +43,7 @@ function handleAuxiliaryResponse(response) {
 
 // Returns the response body as a stream.
 function handleImage(response) {
-  const content = response.headers.get('content-type');
-  const snapshot = response.body;
-  return new Promise((resolve) => {
-    snapshot.on('readable', () => {
-      const buffer = snapshot.read();
-      if (buffer !== null && buffer !== undefined) {
-        const str64 = buffer.toString('base64');
-        const img = `data:${content};base64,${str64}`;
-        resolve(img);
-      }
-    });
-  });
+  return response;
 }
 
 function handleSuccess(response) {

--- a/flux-sdk-node/package.json
+++ b/flux-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-sdk-node",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Flux JavaScript SDK for Node clients",
   "files": [
     "es",
@@ -42,7 +42,7 @@
     "supertest": "^1.2.0"
   },
   "dependencies": {
-    "flux-sdk-common": "^0.5.1",
+    "flux-sdk-common": "^0.5.2",
     "node-fetch": "^1.3.3",
     "ws": "^1.0.1"
   }

--- a/flux-sdk-node/spec/e2e/bcf/viewpoint-spec.js
+++ b/flux-sdk-node/spec/e2e/bcf/viewpoint-spec.js
@@ -81,7 +81,8 @@ describe('Viewpoint', function() {
         this.topic.createViewpoint(testViewpoint)
         .then((viewpoint) => {
           viewpoint.getSnapshot().then((snapshot) => {
-            expect(snapshot).toContain('data:image/png;base64,');
+            expect(snapshot.url.slice(0, 4)).toEqual('http');
+            expect(snapshot.url).toContain('snapshot');
           }).then(done, done.fail);
         });
       });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flux-sdk-js",
   "description": "Not for direct usage",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "scripts": {
     "build": "echo \"please run './build.sh' from the command line\"",
     "clean": "./clean.sh",


### PR DESCRIPTION
Fix bugs in v0.5.1. Image snapshot serialization was only
working in node, not browser. Now we return the raw request
object and leave the environment specific handling up to the
client.